### PR TITLE
adding arbitrary tags to a thread

### DIFF
--- a/notmuch-ruby.vim
+++ b/notmuch-ruby.vim
@@ -200,6 +200,7 @@ function! s:search_tag(intags)
 	endif
 	ruby do_tag(get_thread_id, VIM::evaluate('l:tags'))
 	norm j
+	call s:search_refresh()
 endfunction
 
 function! s:folders_search_prompt()


### PR DESCRIPTION
I needed a way to add arbitrary tags to threads, so I added an input() call if the *_tag functions are called with an empty string. I also made it easier to add tags by assuming +. 

I also added a refresh after adding a tag since the display wasn't showing the new tag. I'm not sure if that's the best way to update the tag list on the thread.
