### PR TITLE
Reply quote

### DIFF
--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -589,6 +589,7 @@ ruby << EOF
 			addr = Mail::Address.new(orig[:from].value)
 			name = addr.name
 			name = addr.local + "@" if name.nil? && !addr.local.nil?
+                        name = "%s <%s>" % [name, addr.address] if !addr.address.nil?
                         if !orig.date.nil?
                             quote_datetime_format = VIM::evaluate('g:notmuch_reply_quote_datetime_format')
                             quote_datetime = orig.date.strftime quote_datetime_format


### PR DESCRIPTION
Improves the quote line on replies by including the original date and the email address of the original sender. Datetime can be customized by overwriting `g:notmuch_reply_quote_datetime_format`

```
On Sat, 2013-11-22 at 17:53:43 -0800,  Git <git@github.com> wrote:
> Pull request...
```
