### PR TITLE
Omit exclude_tags in searches

### DIFF
--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -699,6 +699,12 @@ ruby << EOF
 		def query(*args)
 			q = @db.query(*args)
 			@queries << q
+			exclude_tags = $config['search.exclude_tags']
+			if !exclude_tags.nil?
+				exclude_tags.split(/;/).each do |exclude|
+					q.add_tag_exclude(exclude)
+				end
+			end
 			q
 		end
 


### PR DESCRIPTION
notmuch supports excluding tags in search

```
[search]
exclude_tags=spam;deleted;killed
```

But these tags seem to be included in search folders. This patch explicitly adds the tags in your config to be excluded from queries. Notmuch will only include these tags if they were explicitly included in the query.
