### PR TITLE
consult a global vim var to get the html handler

### DIFF
--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -919,7 +919,8 @@ ruby << EOF
 				if mime_type != "text/html"
 					text = decoded
 				else
-					IO.popen("elinks --dump", "w+") do |pipe|
+					IO.popen(VIM::evaluate('exists("g:notmuch_html_converter") ? ' +
+							'g:notmuch_html_converter : "elinks --dump"'), "w+") do |pipe|
 						pipe.write(decode_body)
 						pipe.close_write
 						text = pipe.read


### PR DESCRIPTION
I don't have elinks on my machine so the default config won't read html messages - suggestion is to provide a way to customise (from vim) the tool that is used to convert html messages.
