### PR TITLE
Makefile: notmuch.vim and notmuch.txt live in subdirs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,10 @@ all:
 	@echo "Nothing to build"
 
 install:
-	$(INSTALL) $(CURDIR)/notmuch.vim $(D)$(prefix)/plugin/notmuch.vim
-	$(INSTALL) $(CURDIR)/notmuch.txt $(D)$(prefix)/doc/notmuch.txt
+	@$(foreach file,$(wildcard plugin/*), \
+		$(INSTALL) $(CURDIR)/$(file) $(D)$(prefix)/$(file);)
+	@$(foreach file,$(wildcard doc/*), \
+		$(INSTALL) $(CURDIR)/$(file) $(D)$(prefix)/$(file);)
 	@$(foreach file,$(wildcard syntax/*), \
 		$(INSTALL) $(CURDIR)/$(file) $(D)$(prefix)/$(file);)
 


### PR DESCRIPTION
Both files were moved out of the top-level directory into subdirectories
in dfb5da86df23, "Reorganize files" which was introduced in response to
issue #5, "compatibility with Vundle".

Makefile was not updated causing the following error:

  $ make install
  install -v -D -m644 /src/notmuch-vim/plugin/ /dest/.vim/plugin/
  install: omitting directory ‘/src/notmuch-vim/plugin/’
  make: **\* [install] Error 1

Additionally the method used to populate the plugin and doc directories
was updated to iterate over all files in those directories. This
future-proofs those directories in the event that new files are someday
added to them.

Signed-off-by: Michael Turquette mturquette@deferred.io
