### PR TITLE
Show attachments on show mode.

### DIFF
--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -327,6 +327,9 @@ ruby << EOF
 			b << "Cc: %s" % msg['cc']
 			b << "Date: %s" % msg['date']
 			nm_m.body_start = b.count
+			m.attachments.each do |att|
+				b << "--- %s ---" % att.filename
+			end
 			b << "--- %s ---" % part.mime_type
 			part.convert.each_line do |l|
 				b << l.chomp


### PR DESCRIPTION
When showing a mail with attachments, show the list of attachments before the text of the mail.