### PR TITLE
Fix deprecated call to File.exists?()

### DIFF
--- a/plugin/notmuch.vim
+++ b/plugin/notmuch.vim
@@ -543,7 +543,7 @@ ruby << EOF
 			f.puts(lines)
 
 			sig_file = File.expand_path('~/.signature')
-			if File.exists?(sig_file)
+			if File.exist?(sig_file)
 				f.puts("-- ")
 				f.write(File.read(sig_file))
 			end


### PR DESCRIPTION
With Ruby 3.2.0 the plural "exists" methods are all singular.

Otherwise, this error throws when composing a message:

    Error detected while processing function <SNR>16_compose:
    line    1:
    NoMethodError: undefined method 'exists?' for class File
    eval:94:in 'block in Object#open_compose_helper'
    /usr/share/ruby/tempfile.rb:444:in 'Tempfile.open'
    eval:88:in 'Object#open_compose_helper'
    eval:165:in 'Object#open_compose'
    eval:1:in '<main>'